### PR TITLE
Remove instances of testing against byte strings

### DIFF
--- a/CS_Image_Access.ipynb
+++ b/CS_Image_Access.ipynb
@@ -28,6 +28,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import warnings\n",
+    "\n",
     "import numpy as np\n",
     "\n",
     "import matplotlib\n",
@@ -41,11 +43,12 @@
     "# For downloading files\n",
     "from astropy.utils.data import download_file\n",
     "\n",
-    "import aplpy\n",
+    "with warnings.catch_warnings():\n",
+    "    warnings.filterwarnings(\"ignore\", module=\"astropy.nddata.utils\")\n",
+    "    import aplpy\n",
     "from IPython.display import Image as ipImage, display\n",
     "\n",
     "# There are a number of relatively unimportant warnings that show up, so for now, suppress them:\n",
-    "import warnings\n",
     "warnings.filterwarnings(\"ignore\", module=\"astropy.io.votable.*\")\n",
     "warnings.filterwarnings(\"ignore\", module=\"pyvo.utils.xml.*\")"
    ]
@@ -347,7 +350,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.10"
+   "version": "3.7.9"
   }
  },
  "nbformat": 4,

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -56,16 +56,10 @@ services[0].search(...)
 sends a query to the first service, and for easier browsing of the results, you can use an Astropy table:
 
 ```
-services.to_table()[0]['short_name', ivoid', 'access_url']
+services.to_table()[0]['short_name', 'ivoid', 'access_url']
 ```
 
-This is fine for browsing.  But to do actual table operations like searching for matches in the columns, you have to use it as an Astropy table, e.g., 
-
-```
-services.to_table()[ np.isin(services.to_table()['short_name'], 'GALEX') ]['ivoid','access_url']
-```
 but this doesn't give you something callable.  It gives you an Astropy table, not a PyVO object with a search() method.  
-
 
 **Workaround**:  To select a service whose short_name matches, e.g., 'GALEX', the easiest way is
 

--- a/UseCase_I.ipynb
+++ b/UseCase_I.ipynb
@@ -117,8 +117,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Byte strings it is!\n",
-    "galaxies = objects_in_paper[objects_in_paper['Type'] == b'G']\n",
+    "# Recast the Type column as strings, to avoid any issues with byte strings\n",
+    "galaxies = objects_in_paper[np.array(objects_in_paper['Type'], dtype='str') == 'G']\n",
     "\n",
     "galaxies.show_in_notebook()"
    ]
@@ -444,7 +444,7 @@
     "\n",
     "Hints:\n",
     "* Search the registry using `keywords=['sloan']\n",
-    "* Find the service with a `short_name` of `b'SDSS SIAP'`\n",
+    "* Find the service with a `short_name` of `'SDSS SIAP'`\n",
     "* From Known Issues, recall that an empty string must be specified to the `format` parameter dues to a bug in the service.\n",
     "* After obtaining your search results, select r-band images using the `.title` attribute of the records that are returned, since `.bandpass_id` is not populated."
    ]
@@ -667,7 +667,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.10"
+   "version": "3.7.9"
   }
  },
  "nbformat": 4,

--- a/UseCase_II.ipynb
+++ b/UseCase_II.ipynb
@@ -143,8 +143,8 @@
    "outputs": [],
    "source": [
     "uv_services.to_table()[\n",
-    "    np.isin(uv_services.to_table()['short_name'],b'GALEX')\n",
-    "    ]['ivoid','short_name','access_url']"
+    "    np.array(['GALEX' in u.short_name for u in uv_services])\n",
+    "    ]['ivoid', 'short_name', 'access_url']"
    ]
   },
   {
@@ -249,7 +249,7 @@
     "xim_table=x_services[0].search(pos=pos,size=0.2)\n",
     "## Some of these are FITS and some JPEG.  Look at the columns:\n",
     "print( xim_table.to_table().columns )\n",
-    "first_fits_image_row=xim_table[ int(np.where(np.isin(xim_table.to_table()['imgfmt'],b'image/fits'))[0][0]) ] "
+    "first_fits_image_row = [x for x in xim_table if 'image/fits' in x.format][0] "
    ]
   },
   {
@@ -408,7 +408,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.7.9"
   },
   "nav_menu": {},
   "toc": {

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - python=3.7
   - numpy
-  - astropy>=4.0
+  - astropy>=4.1
   - matplotlib
   - requests
   - jupyterlab>=2.0


### PR DESCRIPTION
The astropy 4.1 release includes the fixes to `astropy.io.votable` by @tomdonaldson that previously caused byte columns to be returned in Astropy tables. The changes in this pull request alter the handful of cases where we showed selection using byte strings, to remove these tests. These code changes should make the notebooks work with both astropy 4.1 and with previous versions.

Some additional cleanup of whitespace and wording in `KNOWN_ISSUES.md` has also been done, as well as suppressing a new warning from importing aplpy in the CS_Image_Access notebook.