### PR TITLE
Lock pyvo and astroquery versions for AAS 238

### DIFF
--- a/QuickReference.ipynb
+++ b/QuickReference.ipynb
@@ -215,7 +215,7 @@
    "outputs": [],
    "source": [
     "m83_pos = SkyCoord('13h37m00.950s -29d51m55.51s')\n",
-    "results = services[0].search(pos=m83_pos, size=.2)\n",
+    "results = services[1].search(pos=m83_pos, size=.2)\n",
     "\n",
     "# We can look at the results.\n",
     "results.to_table()"

--- a/environment.yml
+++ b/environment.yml
@@ -12,6 +12,6 @@ dependencies:
   - aplpy
   - pip
   - pip:
-    - astroquery
+    - git+https://github.com/astropy/astroquery.git@77986a0657458898cf21ee590cd7dbc81f9f777a
     - jupyter-offlinenotebook
-    - pyvo>=1.1
+    - git+https://github.com/astropy/pyvo.git@c7a2ebad95629932775fb0966a6a79aec23b6dda


### PR DESCRIPTION
and also work around GALEX image search issue in QuickReference.ipynb by using a different service. (see #26 )

## Changes to the environment
For AAS 238, we would like to lock the versions of pyvo and astroquery to be recent versions from their master branches, while keeping the version fixed to ensure stability throughout the workshop.

For pyvo, lock the version at this PR merge since we will use the functionality from that PR:  https://github.com/astropy/pyvo/commit/c7a2ebad95629932775fb0966a6a79aec23b6dda

For astroquery, lock the version at the most recent PR merged.  We don't specifically need that functionality, but want to be up to date with close to the latest prerelease version since v0.4.1 is quite old.  NB there is a known pip installation issue (https://github.com/astropy/astroquery/issues/1920) with astroquery pre-releases, so using this specific version may help avoid that.  We are using the version corresponding to this commit:  https://github.com/astropy/astroquery/commit/77986a0657458898cf21ee590cd7dbc81f9f777a

## Testing
I was able to use the `nbcollection` functionality shown in PR #25 to verify that all notebooks that ran successfully before this change, still run, and the ones that fail are failing for the same reason as before (`UseCase_I.ipynb` and `UseCase_II.ipynb` due to #26 and `CS_UCDs.ipynb` due to #27).

Once you are in the `navo-workshop` environment created with `conda env create --file environment.yml`, these commands install the extras necessary:
```bash
pip install git+https://github.com/astropy/nbcollection
python -m ipykernel install --user --name navo-workshop
```

These example show how to run the notebooks:
```bash
# Run all the notebooks.  The --overwrite forces the notebook to be run even if it had already been run.
python -m nbcollection execute --overwrite .

# Run a single notebook.
python -m nbcollection execute --overwrite QuickReference.ipynb
```
