### PR TITLE
Unpin astroquery version (0.4.2 released), and ignore _build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,7 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# nbcollection output
+_build/
+

--- a/environment.yml
+++ b/environment.yml
@@ -12,6 +12,6 @@ dependencies:
   - aplpy
   - pip
   - pip:
-    - git+https://github.com/astropy/astroquery.git@77986a0657458898cf21ee590cd7dbc81f9f777a
+    - astroquery
     - jupyter-offlinenotebook
     - git+https://github.com/astropy/pyvo.git@c7a2ebad95629932775fb0966a6a79aec23b6dda


### PR DESCRIPTION
Astroquery 0.4.2 was release shortly after we pinned the astroquery version to the head of the main github branch, so unpinning will give us all the same functionality without the hacky `environment.yml`.

Also gitignored the `_build` directory which is created if one uses the `nbcollection` package to execute the notebooks from the command line.