### PR TITLE
Tjissue16:  update data discovery in Catalogs cheat sheet

### DIFF
--- a/CS_Catalog_Queries.ipynb
+++ b/CS_Catalog_Queries.ipynb
@@ -105,9 +105,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Supposing that we want the table with the short_name CFAZ, and we want to retrieve the data for all sources within an arcminute of our specified location:\n",
-    "\n",
-    "(Note that currently, it's a bit ugly to retrieve the specific service we want.)  "
+    "Supposing that we want the table with the short_name CFAZ, and we want to retrieve the data for all sources within an arcminute of our specified location:"
    ]
   },
   {
@@ -150,15 +148,66 @@
    "source": [
     "## 2.1  TAP services\n",
     "\n",
-    "Many services list a single TAP service in the Registry that can access many catalogs, boosting your efficiency. This is the power of the TAP! \n",
-    "With the TAP, you can refine the search based on any other attribute in the given catalog. Suppose for our example, we want to select bright galaxy candidates but don't know the coordinates. Therefore, we start from figuring out the best table to query.   "
+    "Many services list a single TAP service in the Registry that can access many catalogs, boosting your efficiency, and letting you add constraints based on any column. This is the power of the TAP!  \n",
+    "\n",
+    "Suppose for our example, we want to select bright galaxy candidates but don't know the coordinates. Therefore, we start from figuring out the best table to query.   "
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As before, we use the vo.regsearch() for a servicetype 'tap'.  There are a lot of TAP services in the registry, so we're going to limit our search to those related to the HEASARC.  "
+    "As before, we use the `vo.regsearch()` for a servicetype 'tap'.  There are a lot of TAP services in the registry, but they are listed slightly differently than cone services.  The metadata on each catalog is usually published in the registry with its cone service, and then the full TAP service is listed as an \"auxiliary\" service.  So to find a TAP service for a given catalog, we need to add the option *includeaux=True*. Alternatively, you can start with a single TAP service and then ask it specifically which tables it serves, but for this use case, that is less efficient. \n",
+    "\n",
+    "We'll first do a registry search for all auxiliary TAP services related to the \"CfA\" and \"redshift\". "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "tap_services = vo.regsearch(servicetype='tap', keywords=['cfa redshift'], includeaux=True)\n",
+    "tap_services.to_table()['ivoid', 'short_name', 'res_title']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There are many tables that mention these keywords. Pick some likely looking ones and look at the descriptions:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "for t in tap_services:\n",
+    "    if \"cfa\" in t.res_title.lower() and \"magnitude\" in t.res_description.lower():\n",
+    "        print(f\"{t.ivoid}:  {t.res_description}\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "From the above information, you can choose the table you want and then use the specified TAP service to query it as described below.  \n",
+    "\n",
+    "But first we'll look at the other way of finding tables to query with TAP:  by starting with the TAP services listed individually in the Registry.  We see above that the HEASARC has the ZCAT, so what else does it have?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can find out which tables a TAP serves and then look at the tables descriptions. The last line here sends a query directly to the service to ask it for a list of tables.  (This can take a minute, since there may be a lot of tables.)"
    ]
   },
   {
@@ -167,15 +216,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "heasarc_tap_services = vo.regsearch(servicetype='tap', keywords=['heasarc'])\n",
-    "heasarc_tap_services.to_table()['ivoid', 'short_name', 'res_title']"
+    "#  Here, we're looking for a specific service, and we don't need the includeaux option:\n",
+    "tap_services = vo.regsearch(servicetype='tap',keywords=['heasarc'])\n",
+    "heasarc = tap_services[0]\n",
+    "heasarc_tables=heasarc.service.tables "
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "So there's only one HEASARC TAP service.  But it serves many different tables.  What are they?  This sends a query to the service to ask.  Then let's look for results related to the string 'zcat':"
+    "Then let's look for tables matching the terms we're interested in as above.  "
    ]
   },
   {
@@ -184,9 +235,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "heasarc_tables = heasarc_tap_services[0].service.tables\n",
     "for tablename in heasarc_tables.keys():\n",
-    "    if \"zcat\" in tablename:  \n",
+    "    if \"redshift\" in heasarc_tables[tablename].description.lower():  \n",
     "        heasarc_tables[tablename].describe()\n",
     "        print(\"Columns={}\".format(sorted([k.name for k in heasarc_tables[tablename].columns ])))\n",
     "        print(\"----\")"
@@ -196,7 +246,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Success! This appears to be useful table for our goal since it contains columns with the information that we need to select a sample of the brightest nearby spiral galaxy candidates. \n",
+    "There are a number of tables that appear to be useful table for our goal, including the ZCAT,  which contains columns with the information that we need to select a sample of the brightest nearby spiral galaxy candidates. \n",
     "\n",
     "Now that we know all the possible column information in the zcat catalog, we can do more than query on position (as in a cone search) but also on any other column (e.g., redshift, bmag, morph_type).  The query has to be expressed in a language called __[ADQL](http://www.ivoa.net/documents/latest/ADQL.html)__.  \n"
    ]
@@ -289,8 +339,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "results = heasarc_tap_services[0].service.run_async(query)\n",
-    "#results=heasarc_tap_services[0].search(query) \n",
+    "results=heasarc.service.run_async(query) \n",
+    "#results = heasarc.search(query)\n",
     "results.to_table()"
    ]
   },
@@ -335,8 +385,8 @@
    },
    "outputs": [],
    "source": [
-    "results = heasarc_tap_services[0].service.run_async(query)\n",
-    "#results = heasarc_tap_services[0].search(query)\n",
+    "results = heasarc.service.run_async(query)\n",
+    "#results = heasarc.search(query)\n",
     "results.to_table()"
    ]
   },
@@ -361,7 +411,7 @@
    },
    "outputs": [],
    "source": [
-    "heasarc_tap_services[0].service.examples[0]"
+    "heasarc.service.examples[0]"
    ]
   },
   {
@@ -377,7 +427,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for example in heasarc_tap_services[0].service.examples:\n",
+    "for example in heasarc.service.examples:\n",
     "    print(example['QUERY'])\n",
     "    result=example.execute()\n",
     "    #  Stop at one\n",
@@ -412,7 +462,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "heasarc_tap_services[0].service.upload_methods"
+    "heasarc.service.upload_methods"
    ]
   },
   {
@@ -435,8 +485,8 @@
     "    contains(point('ICRS',cat.ra,cat.dec),circle('ICRS',mt.ra,mt.dec,0.01))=1\n",
     "    and Radial_Velocity > 0\n",
     "    ORDER by cat.ra\"\"\"\n",
-    "zcattable = heasarc_tap_services[0].service.run_async(query, uploads={'mysources': 'data/my_sources.xml'})\n",
-    "#zcattable = heasarc_tap_services[0].search(query, uploads={'mysources': 'data/my_sources.xml'})\n",
+    "zcattable = heasarc.service.run_async(query, uploads={'mysources': 'data/my_sources.xml'})\n",
+    "#zcattable = heasarc.search(query, uploads={'mysources': 'data/my_sources.xml'})\n",
     "mytable = zcattable.to_table()\n",
     "mytable"
    ]
@@ -486,7 +536,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This time, rather than write the table to disk, we'll keep it in memory and give Tap.query() a \"file-like\" object using io.BytesIO():"
+    "Now we construct and run a query that uses the new angDdeg column in every row search. Note, we also don't want to list the original candidates since we know these are in the catalog and we want rather to find any companions. Therefore, we exclude the match if the radial velocities match exactly.\n",
+    "\n",
+    "This time, rather than write the table to disk, we'll keep it in memory and give Tap.query() a \"file-like\" object using io.BytesIO().  This can take half a minute:  "
    ]
   },
   {
@@ -499,24 +551,7 @@
     "vot_obj=io.BytesIO()\n",
     "apvot.writeto(apvot.from_table(mytable),vot_obj)\n",
     "## (Reset the \"file-like\" object to the beginning.)\n",
-    "vot_obj.seek(0)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now we construct and run a query that uses the new angDdeg column in every row search. Note, we also don't want to list the original candidates since we know these are in the catalog and we want rather to find any companions. Therefore, we exclude the match if the radial velocities match exactly.\n",
-    "\n",
-    "This takes half a minute:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "vot_obj.seek(0)\n",
     "query=\"\"\"SELECT mt.ra, mt.dec, cat.ra, cat.dec, cat.Radial_Velocity, cat.morph_type, cat.bmag \n",
     "    FROM zcat cat, tap_upload.mytable mt \n",
     "    WHERE\n",
@@ -524,8 +559,8 @@
     "    and cat.Radial_Velocity > 0 and cat.radial_velocity != mt.radial_velocity\n",
     "    ORDER by cat.ra\"\"\"\n",
     "#  Currently broken due to a bug.\n",
-    "#mytable2 = heasarc_tap_services[0].service.run_async(query, uploads={'mytable':vot_obj})\n",
-    "mytable2 = heasarc_tap_services[0].search(query, uploads={'mytable':vot_obj})\n",
+    "#mytable2 = heasarc.service.run_async(query, uploads={'mytable':vot_obj})\n",
+    "mytable2 = heasarc.search(query, uploads={'mytable':vot_obj})\n",
     "vot_obj.close()\n",
     "mytable2.to_table()"
    ]
@@ -556,35 +591,14 @@
     "\n",
     "For very large queries, or for submitting queries in parallel, you may wish to use the `submit_job()`, `wait()`, and `fetch_results()` methods to avoid locking up your Python session.  This is described in the [pyvo documentation](https://pyvo.readthedocs.io/en/latest/dal/index.html#jobs).\n"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [conda env:navo-env]",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-navo-env-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -596,7 +610,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.10"
+   "version": "3.7.10"
   }
  },
  "nbformat": 4,

--- a/CS_Catalog_Queries.ipynb
+++ b/CS_Catalog_Queries.ipynb
@@ -596,9 +596,9 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [conda env:navo-env]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-navo-env-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/CS_UCDs.ipynb
+++ b/CS_UCDs.ipynb
@@ -253,9 +253,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:navo-env]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-navo-env-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/CS_UCDs.ipynb
+++ b/CS_UCDs.ipynb
@@ -152,7 +152,7 @@
     "#  Look for all TAP services with x-ray and optical data\n",
     "collection={}\n",
     "for s in vo.regsearch(servicetype='tap',keywords=['x-ray','optical']):\n",
-    "    #if \"wfau\" in s.ivoid:  continue #  These sometimes have issues\n",
+    "    if \"wfau\" in s.ivoid:  continue #  These sometimes have issues\n",
     "    print(f\"Looking at service from {s.ivoid}\")\n",
     "    try:\n",
     "        tables=s.service.tables\n",
@@ -253,9 +253,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:pyvo-dev]",
+   "display_name": "Python [conda env:navo-env]",
    "language": "python",
-   "name": "conda-env-pyvo-dev-py"
+   "name": "conda-env-navo-env-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -267,7 +267,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.7.10"
   }
  },
  "nbformat": 4,

--- a/CS_UCDs.ipynb
+++ b/CS_UCDs.ipynb
@@ -26,12 +26,9 @@
     "# Generic VO access routines\n",
     "import pyvo as vo\n",
     "\n",
-    "# For specifying coordinates\n",
-    "from astropy.coordinates import SkyCoord\n",
-    "\n",
     "# Ignore unimportant warnings\n",
     "import warnings\n",
-    "warnings.filterwarnings('ignore', '.*Unknown element mirrorURL.*', vo.utils.xml.elements.UnknownElementWarning)"
+    "warnings.filterwarnings('ignore', '.*Unknown element .*', vo.utils.xml.elements.UnknownElementWarning)\n"
    ]
   },
   {
@@ -143,7 +140,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In particular, you can use the UCDs to look for catalogs that might have the information you're interested in. Then you can code the same query to work for different tables (with different column names) in a loop.  This sends a bunch of queries but doesn't take too long, a minute maybe.    "
+    "In particular, you can use the UCDs to look for catalogs that might have the information you're interested in. Then you can code the same query to work for different tables (with different column names) in a loop.  This sends a bunch of queries but doesn't take too long, a minute maybe. (One is particularly slow.)  "
    ]
   },
   {
@@ -152,14 +149,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "coord = SkyCoord.from_name(\"m83\")\n",
-    "query=f\"select top 10 {ra_name}, {dec_name} from dbo.DetailedCatalog\"\n",
     "#  Look for all TAP services with x-ray and optical data\n",
     "collection={}\n",
     "for s in vo.regsearch(servicetype='tap',keywords=['x-ray','optical']):\n",
-    "    if \"wfau\" in s.ivoid:  continue #  These sometimes have issues\n",
+    "    #if \"wfau\" in s.ivoid:  continue #  These sometimes have issues\n",
     "    print(f\"Looking at service from {s.ivoid}\")\n",
-    "    tables=s.service.tables\n",
+    "    try:\n",
+    "        tables=s.service.tables\n",
+    "    except:\n",
+    "        print(\"Problem with this service's tables endpoint.  Continuing to next.\")\n",
+    "        continue\n",
     "    #  Find all the tables that have an RA,DEC and a start and end time\n",
     "    for t in tables:\n",
     "        names={}\n",
@@ -168,17 +167,23 @@
     "            if len(cols) > 0:  \n",
     "                names[ucd]=cols[0]  # use the first that matches\n",
     "        if len(names.keys()) == 4:  \n",
-    "            query=\"select top 10 {}, {}, {}, {} from {}\".format(\n",
-    "                names['pos.eq.ra'],\n",
-    "                names['pos.eq.dec'],\n",
-    "                names['time.start'],\n",
-    "                names['time.end'],\n",
-    "                t.name)\n",
-    "            query=f\"select top 10 * from {t.name}\"\n",
-    "            print(f\"    Table {t.name} has the right columns.  Executing query\")\n",
-    "            results=s.search(query)\n",
-    "            print(\"    Found {} results\\n\".format(len(results)))\n",
-    "            #  Careful.  We're assuming the table names are unique\n",
+    "            print(f\"    Table {t.name} has the right columns.  Counting rows matching my time.\")\n",
+    "            #  For a first look, a very simple query counting rows in a \n",
+    "            #  time range of interest:\n",
+    "            query=f\"select count({names['time.start']}) from {t.name}\" \\\n",
+    "                  f\" where {names['time.start']} > 52000 \" \n",
+    "            try:\n",
+    "                results=s.search(query)\n",
+    "            except:\n",
+    "                print(\"Problem executing query.  Continuing to next.\")\n",
+    "                continue\n",
+    "            #  For this simple query, the result is a single number, the count.  \n",
+    "            #   But different services might name the result differently, so \n",
+    "            #   don't assume you know the column  name.  \n",
+    "            print(\"    Found {} results from {}\\n\".format(results.to_table()[0][0],t.name))\n",
+    "            #  If the query above asked for the matching data rather than the\n",
+    "            #  count, you might want to collect the results.  \n",
+    "            #  Careful:  here we're assuming the table names are unique\n",
     "            collection[t.name]=results\n"
    ]
   },
@@ -190,7 +195,7 @@
     "\n",
     "Note, however,  that returning the UCDs as part of the result is not mandatory, and some services do not do it.  So you'll have to check.\n",
     "\n",
-    "Now we have a collection of rows from different tables with different columns.  In the results object, we have access to a fieldname_with_ucd() function to get the column you want.  Let's find out which of these tables has a magnitude column:"
+    "Now we have a collection of rows from different tables with different columns.  In the results object, we have access to a fieldname_with_ucd() function to get the column you want.  Supposing we hadn't already looked for this in the above loop, let's now find out which of these tables has a magnitude column:"
    ]
   },
   {
@@ -248,9 +253,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [conda env:pyvo-dev]",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-pyvo-dev-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -262,7 +267,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.7.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Some reworking to clarify how to search for catalogs served by TAP with the includeaux, and alternate ways to look at tables from a given service, etc.  Note that the last query is broken for async for reasons unknown so it has been set back to the sync.  