### PR TITLE
Add KOA to Quick Reference

### DIFF
--- a/QuickReference.ipynb
+++ b/QuickReference.ipynb
@@ -346,17 +346,20 @@
    "metadata": {},
    "source": [
     "# 3. Astroquery \n",
-    "Many archives have Astroquery modules for data access, including:\n",
+    "Many archives have Astroquery or Astroquery-compliant modules for data access, including:\n",
     "\n",
-    "* [HEASARC Queries (astroquery.heasarc)](https://astroquery.readthedocs.io/en/latest/heasarc/heasarc.html)\n",
-    "* [HITRAN Queries (astroquery.hitran)](https://astroquery.readthedocs.io/en/latest/hitran/hitran.html)\n",
-    "* [IRSA Image Server program interface (IBE) Queries (astroquery.ibe)](https://astroquery.readthedocs.io/en/latest/ibe/ibe.html)\n",
-    "* [IRSA Queries (astroquery.irsa)](https://astroquery.readthedocs.io/en/latest/irsa/irsa.html)\n",
-    "* [IRSA Dust Extinction Service Queries (astroquery.irsa_dust)](https://astroquery.readthedocs.io/en/latest/irsa/irsa_dust.html)\n",
-    "* [JPL Spectroscopy Queries (astroquery.jplspec)](https://astroquery.readthedocs.io/en/latest/jplspec/jplspec.html)\n",
-    "* [MAST Queries (astroquery.mast)](https://astroquery.readthedocs.io/en/latest/mast/mast.html)\n",
-    "* [NASA ADS Queries (astroquery.nasa_ads)](https://astroquery.readthedocs.io/en/latest/nasa_ads/nasa_ads.html)\n",
-    "* [NED Queries (astroquery.ned)](https://astroquery.readthedocs.io/en/latest/ned/ned.html)\n",
+    "* Astroquery\n",
+    "  * [HEASARC Queries (astroquery.heasarc)](https://astroquery.readthedocs.io/en/latest/heasarc/heasarc.html)\n",
+    "  * [HITRAN Queries (astroquery.hitran)](https://astroquery.readthedocs.io/en/latest/hitran/hitran.html)\n",
+    "  * [IRSA Image Server program interface (IBE) Queries (astroquery.ibe)](https://astroquery.readthedocs.io/en/latest/ibe/ibe.html)\n",
+    "  * [IRSA Queries (astroquery.irsa)](https://astroquery.readthedocs.io/en/latest/irsa/irsa.html)\n",
+    "  * [IRSA Dust Extinction Service Queries (astroquery.irsa_dust)](https://astroquery.readthedocs.io/en/latest/irsa/irsa_dust.html)\n",
+    "  * [JPL Spectroscopy Queries (astroquery.jplspec)](https://astroquery.readthedocs.io/en/latest/jplspec/jplspec.html)\n",
+    "  * [MAST Queries (astroquery.mast)](https://astroquery.readthedocs.io/en/latest/mast/mast.html)\n",
+    "  * [NASA ADS Queries (astroquery.nasa_ads)](https://astroquery.readthedocs.io/en/latest/nasa_ads/nasa_ads.html)\n",
+    "  * [NED Queries (astroquery.ned)](https://astroquery.readthedocs.io/en/latest/ned/ned.html)\n",
+    "* Astroquery-compliant\n",
+    "  * [KOA Queries (pykoa.koa)](https://koa.ipac.caltech.edu/UserGuide/PyKOA/PyKOA.html)\n",
     "\n",
     "For more, see https://astroquery.readthedocs.io/en/latest/\n",
     "\n",
@@ -378,9 +381,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "navo-env",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "navo-env"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -392,7 +395,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/QuickReference.ipynb
+++ b/QuickReference.ipynb
@@ -381,9 +381,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "navo-env",
    "language": "python",
-   "name": "python3"
+   "name": "navo-env"
   },
   "language_info": {
    "codemirror_mode": {
@@ -395,7 +395,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
KOA has an astroquery-compliant module (pyKOA) that was developed for astroquery.
It has been added to the quick reference as astroquery-compliant and has a link to the KOA page with examples on how to use the pyKOA module. 