### PR TITLE
Remove byte string from comparison

### DIFF
--- a/CS_Image_Access.ipynb
+++ b/CS_Image_Access.ipynb
@@ -220,7 +220,7 @@
    "outputs": [],
    "source": [
     "services = vo.regsearch(servicetype='image', keywords=['sloan'], waveband='optical')\n",
-    "services.to_table()[np.where(np.isin(services.to_table()['short_name'], b'SDSSDR7'))]['ivoid', 'short_name']"
+    "services.to_table()[np.where(np.isin(services.to_table()['short_name'], 'SDSSDR7'))]['ivoid', 'short_name']"
    ]
   },
   {


### PR DESCRIPTION
As a holdover from when the result VOTables string values were  `bytes` instead of `str`, we were filtering a table for `short_name` containing `b'SDSSDR7'` and not finding any.  This didn't mess up the next step since repeated the filtering with `'SDSSDR7'`, but the fact that no results were found in the first filter was messy and confusing.

Fixes #36 