### PR TITLE
Enabling HTML rendering and deployment

### DIFF
--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -1,0 +1,6 @@
+matplotlib
+numpy
+astropy
+astroquery
+pyvo
+scipy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,10 +104,35 @@ jobs:
   #    - *save_cache
   #    - run: *execute_nb
 
+
+  build-docs:
+    docker:
+      - image: cimg/python:3.8
+
+    steps:
+      - checkout
+
+      - run:
+          name: Install dependencies
+          command: |
+            pip install -r .binder/requirements.txt -r doc-requirements.txt
+
+      - run:
+          name: Build html
+          no_output_timeout: 30m
+          command: |
+            sphinx-build -b html -D jupyter_execute_notebooks=off . _build/html
+
+      - store_artifacts:
+          path: _build/html
+
+
+
 workflows:
   version: 2
   default:
     jobs:
+      - build-docs
       - test_linux
       # - test_macos
       # - test_windows

--- a/.github/workflows/circleci-artifacts-redirector.yml
+++ b/.github/workflows/circleci-artifacts-redirector.yml
@@ -1,0 +1,14 @@
+name: Run CircleCI artifacts redirector, rendered pages are under Details
+
+on: [status]
+jobs:
+  circleci_artifacts_redirector_job:
+    runs-on: ubuntu-latest
+    name: Run CircleCI artifacts redirector
+    steps:
+      - name: GitHub Action step
+        uses: larsoner/circleci-artifacts-redirector-action@master
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          artifact-path: 0/_build/html/index.html
+          circleci-jobs: build-docs

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -1,0 +1,37 @@
+name: Build & publish documentation to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Insall dependencies
+        run: |
+          pip install -r .binder/requirements.txt -r doc-requirements.txt
+
+      - name: Build the notebooks
+        run: |
+          sphinx-build -b html -D jupyter_execute_notebooks=off . _build/html
+
+
+      - name: GitHub Pages action
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        uses: peaceiris/actions-gh-pages@v3.6.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./_build/html/
+          commit_message: ${{ github.event.head_commit.message }}

--- a/conf.py
+++ b/conf.py
@@ -1,0 +1,73 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'NASA-NAVO Workshop Notebooks'
+copyright = '2018-2022, NASA-NAVO developers'
+author = 'NASA-NAVO developers'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    'myst_nb',
+    'sphinx_copybutton',
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'notes']
+
+# MyST-NB configuration
+execution_timeout = 900
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'sphinx_book_theme'
+html_title = 'NASA-NAVO Workshops Notebooks'
+#html_logo = '_static/navo_logo.gif'
+#html_favicon = '_static/favicon.ico'
+html_theme_options = {
+    "github_url": "https://github.com/NASA-NAVO/navo-workshop",
+    "repository_url": "https://github.com/NASA-NAVO/navo-workshop",
+    "repository_branch": "main",
+    "use_repository_button": True,
+    "use_issues_button": True,
+    "use_edit_page_button": True,
+    "launch_buttons": {
+        "binderhub_url": "https://mybinder.org",
+        "colab_url": "https://colab.research.google.com"
+
+    },
+    "home_page_in_toc": True,
+#    "logo_link_url": "https://astroML.org",
+#    "logo_url": "http://www.astroml.org/_images/plot_moving_objects_1.png"
+}
+
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -1,0 +1,4 @@
+sphinx
+myst-nb
+sphinx-book-theme
+sphinx-copybutton

--- a/index.md
+++ b/index.md
@@ -1,0 +1,23 @@
+# NASA-NAVO notebooks
+
+## Content
+
+```{toctree}
+---
+maxdepth: 2
+---
+
+CS_Catalog_Queries
+CS_Image_Access
+CS_Spectral_Access
+CS_UCDs
+CS_VO_Tables
+Exercise_I
+Exercise_II
+Exercise_III
+QuickReference
+UseCase_I
+UseCase_II
+UseCase_III
+```
+


### PR DESCRIPTION
This PR adds the most basic github actions config for running and deploying HTML rendering of the notebooks. It also adds the rendering job to the circleCI config without removing or cleaning up any of the existing CI.

In this first iteration all the notebooks files are rendered, naturally making a sensible selection, or changes to their order/grouping should be done, and probably is best done in a follow-up focusing on more on the content than on getting the infrastructure off the ground.