### PR TITLE
Notebooks to be excecuted for HTML rendering

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,12 +62,6 @@ execute_nb: &execute_nb
     which python
     python -m nbcollection execute .
 
-convert_nb: &convert_nb
-  name: Convert the notebooks to HTML
-  command: |
-    source activate navo-env
-    which python
-    python -m nbcollection convert .
 
 jobs:
   test_linux:
@@ -80,8 +74,6 @@ jobs:
       - run: *make_env
       - *save_cache
       - run: *execute_nb
-      # TODO: now convert and deploy converted notebooks to gh-pages
-      # - run: *convert_nb  # only do this on linux
 
 
   # test_macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,8 @@ jobs:
           name: Build html
           no_output_timeout: 30m
           command: |
-            sphinx-build -b html -D jupyter_execute_notebooks=off . _build/html
+            # Run only the notebooks that don't have outputs included, more thorough testing should be done in other jobs
+            sphinx-build -b html -D nb_execution_mode=auto . _build/html
 
       - store_artifacts:
           path: _build/html

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -19,14 +19,14 @@ jobs:
         with:
           python-version: 3.8
 
-      - name: Insall dependencies
+      - name: Install dependencies
         run: |
           pip install -r .binder/requirements.txt -r doc-requirements.txt
 
       - name: Build the notebooks
         run: |
-          sphinx-build -b html -D jupyter_execute_notebooks=off . _build/html
-
+          # Run only the notebooks that don't have outputs included
+          sphinx-build -b html -D jupyter_execute_notebooks=auto . _build/html
 
       - name: GitHub Pages action
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}

--- a/conf.py
+++ b/conf.py
@@ -37,8 +37,7 @@ templates_path = ['_templates']
 exclude_patterns = ['_build', 'notes']
 
 # MyST-NB configuration
-execution_timeout = 900
-
+nb_execution_timeout = 900
 
 # -- Options for HTML output -------------------------------------------------
 


### PR DESCRIPTION
We use `auto` that will leave the option of including outputs for notebooks where we expect the cells to run for a long time.

Note: the rendering should not be the most thorough test, we still need to add e.g. version dependent testing, etc, but that's best done in separate jobs. 