### PR TITLE
Adding minimum numpy version

### DIFF
--- a/.github/workflows/ci_tests_and_publish.yml
+++ b/.github/workflows/ci_tests_and_publish.yml
@@ -26,8 +26,8 @@ jobs:
 
           - name: Linux with the oldest version of dependencies
             os: ubuntu-latest
-            python: '3.9'
-            toxenv: py39-test-oldestdeps
+            python: '3.8'
+            toxenv: py38-test-oldestdeps
 
           - name: OSX
             os: macos-latest

--- a/.github/workflows/ci_tests_and_publish.yml
+++ b/.github/workflows/ci_tests_and_publish.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         include:
 
-          - name: Linux
+          - name: Linux with the oldest version of dependencies
             os: ubuntu-latest
             python: '3.9'
             toxenv: py39-test-oldestdeps

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.9
-  - numpy
+  - numpy>=1.18
   - astropy>=5.0
   - astroquery>=0.4.4
   - matplotlib>=3.1

--- a/tox.ini
+++ b/tox.ini
@@ -21,9 +21,9 @@ deps =
     oldestdeps: numpy==1.18
     oldestdeps: astropy==5.0
     oldestdeps: astroquery==0.4.4
-    oldestdeps: matplotlib==3.1
+    oldestdeps: matplotlib==3.1.2
     oldestdeps: pyvo==1.2
-    oldestdeps: scipy==1.3
+    oldestdeps: scipy==1.4
 
 commands =
     pip freeze

--- a/tox.ini
+++ b/tox.ini
@@ -19,9 +19,11 @@ deps =
     devdeps: git+https://github.com/astropy/pyvo.git#egg=pyvo
 
     oldestdeps: astropy==5.0
+    oldestdeps: numpy==1.18
     oldestdeps: astroquery==0.4.4
     oldestdeps: matplotlib==3.1
     oldestdeps: pyvo==1.2
+    oldestdeps: scipy==1.3
 
 commands =
     pip freeze

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{39,310}-test{,-oldestdeps,-devdeps,-predeps}{,-buildhtml}
+    py{38,39,310}-test{,-oldestdeps,-devdeps,-predeps}{,-buildhtml}
 requires =
     setuptools >= 30.3.0
     pip >= 19.3.1
@@ -18,8 +18,8 @@ deps =
     devdeps: git+https://github.com/astropy/astropy.git#egg=astropy
     devdeps: git+https://github.com/astropy/pyvo.git#egg=pyvo
 
-    oldestdeps: astropy==5.0
     oldestdeps: numpy==1.18
+    oldestdeps: astropy==5.0
     oldestdeps: astroquery==0.4.4
     oldestdeps: matplotlib==3.1
     oldestdeps: pyvo==1.2


### PR DESCRIPTION
This is to fix #87 and hopefully it #86 (and failing CI in the other open PRs, too).


It it comes back with a full green status, I would suggest to get this merged asap.