### PR TITLE
CI:  fix lexer warnings and update actions versions

### DIFF
--- a/.github/workflows/ci_devtests.yml
+++ b/.github/workflows/ci_devtests.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.10'
 

--- a/.github/workflows/ci_tests_and_publish.yml
+++ b/.github/workflows/ci_tests_and_publish.yml
@@ -40,10 +40,10 @@ jobs:
             toxenv: py39-test
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
 
@@ -58,10 +58,10 @@ jobs:
     name: Publish HTML
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
 

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,8 @@ deps =
     oldestdeps: matplotlib==3.1.2
     oldestdeps: pyvo==1.4
     oldestdeps: scipy==1.4
+    # Temporary fix for lexer errors
+    ipython!=8.7.0
 
 commands =
     pip freeze


### PR DESCRIPTION
This is to close #96
 
For more context about the lexer issue see https://github.com/ipython/ipython/issues/13845


Updating the GHA versions should get rid of the actions warnings.