### PR TITLE
Output scrolling

### DIFF
--- a/Exercise_I.ipynb
+++ b/Exercise_I.ipynb
@@ -273,7 +273,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "tags": []
+    "tags": ["output_scroll"]
    },
    "outputs": [],
    "source": [

--- a/Exercise_III.ipynb
+++ b/Exercise_III.ipynb
@@ -61,7 +61,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "tags": []
+    "tags": ["output_scroll"]
    },
    "outputs": [],
    "source": [
@@ -152,7 +152,7 @@
    "execution_count": null,
    "metadata": {
     "scrolled": true,
-    "tags": []
+    "tags": ["output_scroll"]
    },
    "outputs": [],
    "source": [
@@ -175,7 +175,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "tags": []
+    "tags": ["output_scroll"]
    },
    "source": [
     "### Alternative Method: Use ADS to search for appropriate paper and access data via NED.\n",
@@ -277,7 +277,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "tags": []
+    "tags": ["output_scroll"]
    },
    "outputs": [],
    "source": [

--- a/QuickReference.ipynb
+++ b/QuickReference.ipynb
@@ -292,7 +292,7 @@
    "execution_count": null,
    "metadata": {
     "scrolled": true,
-    "tags": []
+    "tags": ["output_scroll"]
    },
    "outputs": [],
    "source": [

--- a/UseCase_I.ipynb
+++ b/UseCase_I.ipynb
@@ -76,7 +76,7 @@
    "execution_count": null,
    "metadata": {
     "scrolled": true,
-    "tags": []
+    "tags": ["output_scroll"]
    },
    "outputs": [],
    "source": [
@@ -107,7 +107,7 @@
    "execution_count": null,
    "metadata": {
     "scrolled": true,
-    "tags": []
+    "tags": ["output_scroll"]
    },
    "outputs": [],
    "source": [

--- a/UseCase_III.ipynb
+++ b/UseCase_III.ipynb
@@ -62,7 +62,7 @@
    "execution_count": null,
    "metadata": {
     "scrolled": true,
-    "tags": []
+    "tags": ["output_scroll"]
    },
    "outputs": [],
    "source": [
@@ -93,7 +93,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "tags": []
+    "tags": ["output_scroll"]
    },
    "outputs": [],
    "source": [
@@ -114,7 +114,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "tags": []
+    "tags": ["output_scroll"]
    },
    "source": [
     "So using this we can reduce the matched tables to ones that are a bit more catered to our experiment. Note, that there can be redundancy in some resources since these are available via multiple services and/or publishers. Therefore a bit more cleaning can be done to provide only the unique matches. "
@@ -124,7 +124,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "tags": []
+    "tags": ["output_scroll"]
    },
    "outputs": [],
    "source": [
@@ -135,7 +135,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "tags": []
+    "tags": ["output_scroll"]
    },
    "outputs": [],
    "source": [
@@ -157,7 +157,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "tags": []
+    "tags": ["output_scroll"]
    },
    "outputs": [],
    "source": [
@@ -169,7 +169,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "tags": []
+    "tags": ["output_scroll"]
    },
    "outputs": [],
    "source": [
@@ -179,7 +179,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "tags": []
+    "tags": ["output_scroll"]
    },
    "source": [
     "This shows that in this case, all of our TAP results are unique. "
@@ -197,7 +197,7 @@
    "execution_count": null,
    "metadata": {
     "scrolled": true,
-    "tags": []
+    "tags": ["output_scroll"]
    },
    "outputs": [],
    "source": [
@@ -214,7 +214,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "tags": []
+    "tags": ["output_scroll"]
    },
    "source": [
     "<i> RESULT: Based on these, the second one (by Eichhorn et al) looks like a good start. </i>\n",
@@ -229,7 +229,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "tags": []
+    "tags": ["output_scroll"]
    },
    "source": [
     "### Alternative Method: Use ADS to search for appropriate paper and access data via NED.\n",
@@ -307,7 +307,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "tags": []
+    "tags": ["output_scroll"]
    },
    "outputs": [],
    "source": [
@@ -355,7 +355,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "tags": []
+    "tags": ["output_scroll"]
    },
    "outputs": [],
    "source": [
@@ -366,7 +366,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "tags": []
+    "tags": ["output_scroll"]
    },
    "outputs": [],
    "source": [
@@ -378,7 +378,7 @@
    "execution_count": null,
    "metadata": {
     "scrolled": true,
-    "tags": []
+    "tags": ["output_scroll"]
    },
    "outputs": [],
    "source": [
@@ -391,7 +391,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "tags": []
+    "tags": ["output_scroll"]
    },
    "source": [
     "## Step 2: Acquire the relevant data and make a plot!\n",
@@ -402,7 +402,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "tags": []
+    "tags": ["output_scroll"]
    },
    "outputs": [],
    "source": [
@@ -418,7 +418,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "tags": []
+    "tags": ["output_scroll"]
    },
    "source": [
     "We can write code to eliminate the other cases (e.g., VI or VIII...) but we wanted to keep this cell to illustrate that the table name (which is required for the query) will likely include the short_name appended to \"/catalog\" (or \"/table\"). \n",
@@ -430,7 +430,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "tags": []
+    "tags": ["output_scroll"]
    },
    "outputs": [],
    "source": [
@@ -445,7 +445,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "tags": []
+    "tags": ["output_scroll"]
    },
    "outputs": [],
    "source": [
@@ -531,7 +531,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "tags": []
+    "tags": ["output_scroll"]
    },
    "outputs": [],
    "source": [


### PR DESCRIPTION
This should fix #102, but I didn't add this to all the cells, only the ones that already had the `tags` metadata.

Ideally we should set the scrolling locally, but I haven't yet found a way to do it only on the cell metadata level.