### PR TITLE
Stop using astropy channel; only conda-forge has latest astropy

### DIFF
--- a/check_env.py
+++ b/check_env.py
@@ -13,10 +13,10 @@ from packaging.version import Version
 # This should match environment.yml file.
 PKGS = {'jupyter': None,
         'notebook': ('6.0', None),
-        'numpy': ('1.16', None),
+        'numpy': ('1.24', None),
         'matplotlib': ('3.2', None),
         'jupyterlab': ('3.0', None),
-        'astropy': ('4.1', None),
+        'astropy': ('5.2', None),
         'pyvo': ('1.4', '1.4'),
         'astroquery': ('0.4.3', None)
         }

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,5 @@
 name: navo-env
 channels:
-  - astropy
   - conda-forge
 dependencies:
   - python=3.9


### PR DESCRIPTION
Fixes #105 by conda installing `astropy` from the `conda-forge` channel rather than the `astropy` channel.  `conda-forge` seems to be the only channel with the latest (`5.2`) version of `astropy`, and `5.2` is needed for compatibility with `numpy==1.24`.

Also updated the `check_env.py` script with latest versions for `astropy` and `numpy`. 