### PR TITLE
CI: fix html rendering CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
 
   build-docs:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.10
 
     steps:
       - checkout
@@ -17,7 +17,7 @@ jobs:
           name: Build HTML rendering of notebooks
           no_output_timeout: 30m
           command: |
-            python -m tox -e py39-buildhtml --
+            python -m tox -e py310-buildhtml --
 
       - store_artifacts:
           path: _build/html

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -1,5 +1,5 @@
 # Doc and testing requirements
-sphinx
+sphinx<5
 myst-nb>=0.14
 sphinx-book-theme
 sphinx-copybutton


### PR DESCRIPTION
For some reason circleCI picks up a rather old sphinx-book-theme and pydata-sphinx-theme versions. This PR should fix that and the build failure (caused by a deprecation)