### PR TITLE
CI: adding workflow_dispatch

### DIFF
--- a/.github/workflows/ci_devtests.yml
+++ b/.github/workflows/ci_devtests.yml
@@ -10,6 +10,7 @@ on:
       - main
   schedule:
     - cron: '0 5 * * 1'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci_tests_and_publish.yml
+++ b/.github/workflows/ci_tests_and_publish.yml
@@ -9,6 +9,7 @@ on:
       - main
   schedule:
     - cron: '0 5 * * 1'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
To make it easier and nicer to trigger a CI run without a PR or making any changes to the repo.