### PR TITLE
Update installation files and instructions

### DIFF
--- a/00_SETUP.md
+++ b/00_SETUP.md
@@ -22,7 +22,7 @@ operating system: [https://docs.conda.io/en/latest/miniconda.html](https://docs.
 Mambaforge. You can obtain an installer for your operating system at
 [https://github.com/conda-forge/miniforge#mambaforge](https://github.com/conda-forge/miniforge#mambaforge).
 Then follow the installation instructions at 
-[https://github.com/conda-forge/miniforge#mambaforge](https://github.com/conda-forge/miniforge#mambaforge).
+[https://github.com/conda-forge/miniforge#install](https://github.com/conda-forge/miniforge#install).
 You can then use `mamba` as a drop-in replacement for  `conda` in the
 installation instructions below.)
 

--- a/00_SETUP.md
+++ b/00_SETUP.md
@@ -16,7 +16,15 @@ conda info
 ```
 
 If Miniconda is not already installed, follow these instructions for your
-operating system: https://docs.conda.io/en/latest/miniconda.html
+operating system: [https://docs.conda.io/en/latest/miniconda.html](https://docs.conda.io/en/latest/miniconda.html)
+
+(If you have trouble installing Miniconda, an alternative is to install
+Mambaforge. You can obtain an installer for your operating system at
+[https://github.com/conda-forge/miniforge#mambaforge](https://github.com/conda-forge/miniforge#mambaforge).
+Then follow the installation instructions at 
+[https://github.com/conda-forge/miniforge#mambaforge](https://github.com/conda-forge/miniforge#mambaforge).
+You can then use `mamba` as a drop-in replacement for  `conda` in the
+installation instructions below.)
 
 On Windows, you might also need
 [additional compilers](https://github.com/conda/conda-build/wiki/Windows-Compilers).
@@ -82,6 +90,8 @@ And finally, on any platform, to install and activate the conda environment for 
 conda env create --file environment.yml
 conda activate navo-env
 ```
+
+The creation of the environment can take some time to run.
 
 ## 6. Check Installation
 

--- a/check_env.py
+++ b/check_env.py
@@ -12,11 +12,11 @@ from packaging.version import Version
 # Set both min and max versions to avoid ambiguity.
 # This should match environment.yml file.
 PKGS = {'jupyter': None,
-        'notebook': ('6.0', None),
         'numpy': ('1.24', None),
         'matplotlib': ('3.2', None),
         'jupyterlab': ('3.1', None),
         'astropy': ('5.2', None),
+        'scipy': ('1.0', None),
         'pyvo': ('1.4', None),
         'astroquery': ('0.4.4', None)
         }

--- a/environment.yml
+++ b/environment.yml
@@ -9,4 +9,4 @@ dependencies:
   - matplotlib>=3.2
   - jupyterlab>=3.1
   - pyvo>=1.4
-  - scipy
+  - scipy>=1.0


### PR DESCRIPTION
* Remove 'notebook' from `check_env.py` as it is not installed with Jupyterlab 4.0.
* Add a check for 'scipy' and a minimum version of 1.0
* Add Mambaforge as an alternative to Miniconda
* Note that the environment installation can take a while

Fixes #117 