### PR TITLE
CI: adding circleCI token

### DIFF
--- a/.github/workflows/circleci-artifacts-redirector.yml
+++ b/.github/workflows/circleci-artifacts-redirector.yml
@@ -10,5 +10,6 @@ jobs:
         uses: larsoner/circleci-artifacts-redirector-action@master
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          api-token: ${{ secrets.NAVO_WORKSHOP_CIRCLE_TOKEN }}
           artifact-path: 0/_build/html/index.html
           circleci-jobs: build-docs


### PR DESCRIPTION
Same as https://github.com/numpy/numpy-tutorials/pull/178, to fix the circleCI redirects