### PR TITLE
Protect against None in table descriptions

### DIFF
--- a/content/reference_notebooks/catalog_queries.md
+++ b/content/reference_notebooks/catalog_queries.md
@@ -176,7 +176,8 @@ Then let's look for tables matching the terms we're interested in as above.
 
 ```{code-cell} ipython3
 for tablename in heasarc_tables.keys():
-    if "redshift" in heasarc_tables[tablename].description.lower():
+    description = heasarc_tables[tablename].description
+    if description and "redshift" in description.lower():
         heasarc_tables[tablename].describe()
         print("Columns={}".format(sorted([k.name for k in heasarc_tables[tablename].columns ])))
         print("----")


### PR DESCRIPTION
This cell was failing because it assumed the table descriptions would be strings, but one (the table called `first`) was `None`.