### PR TITLE
CI: update GHA versions

### DIFF
--- a/.github/workflows/ci_devtests.yml
+++ b/.github/workflows/ci_devtests.yml
@@ -21,10 +21,10 @@ jobs:
     name: Test with development versions of dependencies
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 

--- a/.github/workflows/ci_tests_and_publish.yml
+++ b/.github/workflows/ci_tests_and_publish.yml
@@ -41,10 +41,10 @@ jobs:
             toxenv: py39-test
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
 
@@ -67,8 +67,8 @@ jobs:
         os: ["windows-latest", "ubuntu-latest", "macos-latest"]
 
     steps:
-        - uses: actions/checkout@v3
-        - uses: conda-incubator/setup-miniconda@v2.2.0
+        - uses: actions/checkout@v4
+        - uses: conda-incubator/setup-miniconda@v3
           with:
             environment-file: environment.yml
             activate-environment: navo-env
@@ -84,10 +84,10 @@ jobs:
     name: Publish HTML
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 


### PR DESCRIPTION
This should fix some of the warnings/errors we see, but not the content issues, so I'll go ahead and merge it if the infrastructure warnings are gone.