### PR TITLE
CI: using newer versions and adding prerelease test

### DIFF
--- a/.github/workflows/ci_devtests.yml
+++ b/.github/workflows/ci_devtests.yml
@@ -26,10 +26,10 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - name: Install dependencies
         run: python -m pip install --upgrade tox
 
       - name: Execute notebooks as testing
-        run: tox -e py310-test-devdeps
+        run: tox -e py312-test-devdeps

--- a/.github/workflows/ci_tests_and_publish.yml
+++ b/.github/workflows/ci_tests_and_publish.yml
@@ -40,6 +40,11 @@ jobs:
             python: '3.9'
             toxenv: py39-test
 
+          - name: Python 3.12 and latest or pre-release version of dependencies
+            os: ubuntu-latest
+            python: '3.12'
+            toxenv: py312-test-predeps
+
     steps:
       - uses: actions/checkout@v4
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{39,310,311}-test{,-oldestdeps,-devdeps,-predeps}{,-buildhtml}
+    py{39,310,311,312}-test{,-oldestdeps,-devdeps,-predeps}{,-buildhtml}
 requires =
     setuptools >= 30.3.0
     pip >= 19.3.1


### PR DESCRIPTION
This should close #136

I would not be surprised if we run into a couple of numpy 2.0 issues, but hopefully this doesn't recover some serious issues.