### PR TITLE
MAINT: changing servicetype image/spectrum to sia/ssa

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -16,7 +16,7 @@ PyVO's registry search functions have been updated to allow for more
 powerful methods of data discovery.  Previously you could
 use arguments keywords, servicetype, and waveband, and these still work:
 ```
-image_services = vo.regsearch(servicetype='image', keywords=['sloan vla'])
+image_services = vo.regsearch(servicetype='sia', keywords=['sloan vla'])
 ```
 This searches for the strings 'sloan' AND 'vla' in the same entry.  If you instead used ``keywords=['sloan','vla']``,
 it would return records with either string, not only both.
@@ -38,7 +38,7 @@ the latest documentation of the Registry searching, see
 ## Indexing and slicing registry results
 
 ```
-services=vo.regsearch(servicetype='image')
+services=vo.regsearch(servicetype='sia')
 ```
 
 returns a RegistryResults object.  This works like a list in that
@@ -81,13 +81,13 @@ This part of data discovery is often still a hands-on task based, for example, o
 ## Galex service from STScI doesn't take format specification:
 
 ```
-galex_image_services = vo.regsearch(keywords=['galex'], servicetype='image')[0].search(pos=[0,0], size=0.1)
+galex_image_services = vo.regsearch(keywords=['galex'], servicetype='sia')[0].search(pos=[0,0], size=0.1)
 ```
 
 produces lots. But
 
 ```
-galex_image_services = vo.regsearch(keywords=['galex'], servicetype='image')[0].search(pos=[0,0],
+galex_image_services = vo.regsearch(keywords=['galex'], servicetype='sia')[0].search(pos=[0,0],
     size=0.1, format='image/fits')
 ```
 
@@ -102,7 +102,7 @@ or 'image/jpeg' produces nothing.
 For example,
 
 ```
-services = vo.regsearch(servicetype='image', keywords=['sloan'], waveband='optical')
+services = vo.regsearch(servicetype='sia', keywords=['sloan'], waveband='optical')
 
 jhu_dr7_service = [s for s in services if ('SDSSDR7' in s.short_name) and ('jhu' in s.ivoid)][0]
 

--- a/content/reference_notebooks/basic_reference.md
+++ b/content/reference_notebooks/basic_reference.md
@@ -76,7 +76,7 @@ services
 
 | Argument | Description | Examples |
 | :-----: | :----------- | :-------- |
-| **servicetype** | Type of service | `conesearch` or `scs` for **Simple Cone Search**<br> `image` or `sia` for **Simple Image Access**<br> `spectrum` or `ssa` for **Simple Spectral Access**<br> `table` or `tap` for **Table Access Protocol**|
+| **servicetype** | Type of service | `conesearch` or `scs` for **Simple Cone Search**<br> `sia` for **Simple Image Access**<br>, `ssa` for **Simple Spectral Access**<br> `table` or `tap` for **Table Access Protocol**|
 | **keyword** | List of one or more keyword(s) to match service's metadata. Both ORs and ANDs may be specified.<br><ul><li>(OR) A list of keywords match a service if **any** of the keywords match the service.</li><li>(AND) If a  keyword contains multiple space-delimited words, **all** the words must match the metadata.</li></ul>| `['galex', 'swift']` matches 'galex' or 'swift'<br>`['hst survey']` matches services mentioning both 'hst' and 'survey' |
 | **waveband** | Resulting services have data in the specified waveband(s) | ‘radio’, ‘millimeter’, ‘infrared’, ‘optical’, ‘uv’, ‘euv’, ‘x-ray’ ‘gamma-ray’ |
 

--- a/content/reference_notebooks/basic_reference.md
+++ b/content/reference_notebooks/basic_reference.md
@@ -145,7 +145,7 @@ Example:  Find an image search service for GALEX, and search it around coordinat
 #### Find an image service
 
 ```{code-cell} ipython3
-services = vo.regsearch(servicetype='image', keywords=['galex'])
+services = vo.regsearch(servicetype='sia', keywords=['galex'])
 services.to_table()['ivoid', 'short_name', 'res_title']
 ```
 

--- a/content/reference_notebooks/basic_reference.md
+++ b/content/reference_notebooks/basic_reference.md
@@ -189,7 +189,7 @@ Spectral search is very similar to image search. In this example, note:
 
 ```{code-cell} ipython3
 # Search for a spectrum search service that has x-ray data.
-services = vo.regsearch(servicetype='spectrum', waveband='x-ray')
+services = vo.regsearch(servicetype='ssa', waveband='x-ray')
 
 # Assuming there are services and the first one is OK...
 results = services[0].search(pos=SkyCoord.from_name("Delta Ori"),

--- a/content/reference_notebooks/catalog_queries.md
+++ b/content/reference_notebooks/catalog_queries.md
@@ -100,7 +100,7 @@ Registry services are of the following type:
 
 - simple cone search:  "scs"
 - table access protocol:  "tap" or "table"
-- simple image search:  "sia" or "image"
+- simple image search:  "sia"
 - simple spectral access: "ssa"
 
 There are a number of things in the registry related to 'zcat' so we find the specific one that we want, which is the CFA version:

--- a/content/reference_notebooks/catalog_queries.md
+++ b/content/reference_notebooks/catalog_queries.md
@@ -100,7 +100,7 @@ Registry services are of the following type:
 
 - simple cone search:  "scs"
 - table access protocol:  "tap" or "table"
-- simple image search:  "sia"
+- simple image search:  "sia" or "sia2" for SIAv2 services
 - simple spectral access: "ssa"
 
 There are a number of things in the registry related to 'zcat' so we find the specific one that we want, which is the CFA version:

--- a/content/reference_notebooks/image_access.md
+++ b/content/reference_notebooks/image_access.md
@@ -86,14 +86,14 @@ First, how do we find out what  services are available?  These are listed in a r
 Let's search for services providing images in the ultraviolet bands:
 
 ```{code-cell} ipython3
-uv_services = vo.regsearch(servicetype='image',waveband='uv')
+uv_services = vo.regsearch(servicetype='sia',waveband='uv')
 uv_services.to_table()['ivoid','short_name','res_title']
 ```
 
 This returns an astropy table containing information about the services available.  We can then specify the service we want by using the corresponding row.  We'll repeat the search with additional qualifiers to isolate the row we want (note that in the keyword search the "%" character can be used as a wild card):
 
 ```{code-cell} ipython3
-uvot_services = vo.regsearch(servicetype='image',waveband='uv',keywords=['swift'])
+uvot_services = vo.regsearch(servicetype='sia',waveband='uv',keywords=['swift'])
 uvot_services.to_table()['ivoid','short_name','res_title']
 ```
 
@@ -162,7 +162,7 @@ plt.imshow(hdu_list[0].data, cmap='gray', origin='lower',vmax=0.1)
 Suppose we want Sloan DSS data.  A generic query finds us a number of possibilities (note that this doesn't work for keywords=['sdss'];  be flexible and try several search terms):
 
 ```{code-cell} ipython3
-services = vo.regsearch(servicetype='image', keywords=['sloan'], waveband='optical')
+services = vo.regsearch(servicetype='sia', keywords=['sloan'], waveband='optical')
 services.to_table()[np.where(np.isin(services.to_table()['short_name'], 'SDSSDR7'))]['ivoid', 'short_name']
 ```
 

--- a/content/use_case_notebooks/candidate_list_solution.md
+++ b/content/use_case_notebooks/candidate_list_solution.md
@@ -109,7 +109,7 @@ galaxies.show_in_notebook()
 The paper selected super spirals using WISE, SDSS, and GALEX images. Search the NAVO registry for all image resources, using the 'service_type' search parameter. How many image resources are currently available?
 
 ```{code-cell} ipython3
-image_services = vo.regsearch(servicetype='image')
+image_services = vo.regsearch(servicetype='sia')
 
 print(f'{len(image_services)} result(s) found.')
 
@@ -121,7 +121,7 @@ image_services.to_table()['ivoid', 'short_name', 'res_title']
 There are hundreds of image resources...too many to quickly read through. Try adding the 'keywords' search parameter to your registry search, and find the image resource you would need to search the AllWISE images. Remember from the Known Issues that 'keywords' must be a list.
 
 ```{code-cell} ipython3
-allwise_image_services = vo.regsearch(servicetype='image', keywords=['allwise'])
+allwise_image_services = vo.regsearch(servicetype='sia', keywords=['allwise'])
 
 print(f'{len(allwise_image_services)} result(s) found.')
 
@@ -219,7 +219,7 @@ ax.scatter(ra, dec, transform=ax.get_transform('fk5'), s=500, edgecolor='red', f
 Repeat steps 4, 5, 6, 8 through 12 for GALEX.
 
 ```{code-cell} ipython3
-galex_image_services = vo.regsearch(keywords=['galex'], servicetype='image')
+galex_image_services = vo.regsearch(keywords=['galex'], servicetype='sia')
 print(f'{len(galex_image_services)} result(s) found.')
 galex_image_services.to_table()['ivoid', 'short_name', 'res_title']
 ```
@@ -283,7 +283,7 @@ Hints:
 * After obtaining your search results, select r-band images using the `.title` attribute of the records that are returned, since `.bandpass_id` is not populated.
 
 ```{code-cell} ipython3
-sdss_image_services = vo.regsearch(keywords=['sloan'], servicetype='image')
+sdss_image_services = vo.regsearch(keywords=['sloan'], servicetype='sia')
 sdss_image_services.to_table()['ivoid', 'short_name', 'res_title', 'source_value']
 ```
 

--- a/content/use_case_notebooks/candidate_list_solution.md
+++ b/content/use_case_notebooks/candidate_list_solution.md
@@ -106,7 +106,7 @@ galaxies.show_in_notebook()
 
 ## 4. Search the NAVO Registry for image resources
 
-The paper selected super spirals using WISE, SDSS, and GALEX images. Search the NAVO registry for all image resources, using the 'service_type' search parameter. How many image resources are currently available?
+The paper selected super spirals using WISE, SDSS, and GALEX images. Search the NAVO registry for image resources, using the 'servicetype' search parameter. How many image resources are currently available?
 
 ```{code-cell} ipython3
 image_services = vo.regsearch(servicetype='sia')

--- a/content/use_case_notebooks/proposal_prep_solution.md
+++ b/content/use_case_notebooks/proposal_prep_solution.md
@@ -114,7 +114,7 @@ Hint: Start by checking what UV image services exist (e.g., GALEX?)
 
 ```{code-cell} ipython3
 ## Note that to browse the columns, use the .to_table() method
-uv_services=vo.regsearch(servicetype='image',keywords='galex', waveband='uv')
+uv_services=vo.regsearch(servicetype='sia',keywords='galex', waveband='uv')
 uv_services.to_table()['ivoid','short_name']
 ```
 
@@ -169,7 +169,7 @@ plt.matshow(dataobj[0].data, origin='lower', cmap=cm.gray_r, norm=LogNorm(vmin=0
 Hint: Repeat steps for X-ray image. (Note: Ideally, we would find an image in the Chandra 'cxc' catalog)
 
 ```{code-cell} ipython3
-x_services=vo.regsearch(servicetype='image',keywords=['chandra'], waveband='x-ray')
+x_services=vo.regsearch(servicetype='sia',keywords=['chandra'], waveband='x-ray')
 print(x_services.to_table()['short_name','ivoid'])
 ```
 


### PR DESCRIPTION
Proof of concept to see if how proposed changes of pyvo would look in practice

(this is just sed-ing through the code, the narrative text may need some updates, too)


(Also, I wonder why we only have `'sia'` but not `'sia1'`, as the latter would be the correct, non-ambiguous one, thus I'm opening an upstream, pyvo PR for that)

closes #170