### PR TITLE
DEP: adding astropy[jupyter] to pick up dependencies

### DIFF
--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -1,6 +1,6 @@
 matplotlib
 numpy
-astropy
+astropy[jupyter]
 # we need 0.4.7. for a fix in the caching
 astroquery>=0.4.7dev0
 pyvo>=1.4


### PR DESCRIPTION
 we need these for `.show_in_notebook()`, but will not work with older versions. So I first use CI to smoke things and then adjust the PR.