### PR TITLE
MAINT: remove binder launches

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,6 @@ To create a suitable Python environment for these notebooks, please follow the [
 
 To view the executed notebooks without running them yourself, please see [this page for static renderings of the content](https://nasa-navo.github.io/navo-workshop/).
 
-## Demo in Binder
-
-This badge opens Jupyterlab session on Binder which can be used to run the workshop notebooks.
-
-**Note** that method of running the notebooks is transient, and the session will disappear after
-being left unattended for several minutes.
-
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/NASA-NAVO/notebooks/main?urlpath=lab)
-
-
 ## Running on Sciserver
 
 The workshop notebooks can also be run on [Sciserver](https://sciserver.org/), which offers an online Jupyter platform. To use it for the workshop, follow these steps:

--- a/conf.py
+++ b/conf.py
@@ -55,10 +55,6 @@ html_theme_options = {
     "use_repository_button": True,
     "use_issues_button": True,
     "use_edit_page_button": True,
-    "launch_buttons": {
-        "binderhub_url": "https://mybinder.org",
-
-    },
     "home_page_in_toc": True,
 }
 


### PR DESCRIPTION
Binder feels to be unreliable these days, none of us could launch it during the latest Python WG meeting, so I opened this PR for its removal. However in recent days I had good experience of actually launching it. So if we decide to keep it around for e.g. async learn, #193 provides a fix for launching markdowns as notebooks.

Merge either this one or https://github.com/NASA-NAVO/navo-workshop/pull/193

(closes https://github.com/NASA-NAVO/navo-workshop/pull/193)

