### PR TITLE
MAINT: fix binder launch for markdown notebooks

### DIFF
--- a/overrides.json
+++ b/overrides.json
@@ -1,0 +1,7 @@
+{
+  "@jupyterlab/docmanager-extension:plugin": {
+       "defaultViewers": {
+      "markdown": "Jupytext Notebook"
+    }
+  }
+}

--- a/postBuild
+++ b/postBuild
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -eux
+
+mkdir -p ${NB_PYTHON_PREFIX}/share/jupyter/lab/settings
+cp .binder/overrides.json ${NB_PYTHON_PREFIX}/share/jupyter/lab/settings


### PR DESCRIPTION
This is the alternative for #191, I use the same fix at [IRSA-tutorials](https://caltech-ipac.github.io/irsa-tutorials/) to be able to launch the markdown notebooks into binder.


Merge either this one or #191

(closes #191)
 