### PR TITLE
MAINT: remove colab launch

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -14,7 +14,7 @@
 # -- Project information -----------------------------------------------------
 
 project = 'NASA-NAVO Workshop Notebooks'
-copyright = '2018-2022, NASA-NAVO developers'
+copyright = '2018-2024, NASA-NAVO developers'
 author = 'NASA-NAVO developers'
 
 
@@ -60,8 +60,6 @@ html_theme_options = {
 
     },
     "home_page_in_toc": True,
-#    "logo_link_url": "https://astroML.org",
-#    "logo_url": "http://www.astroml.org/_images/plot_moving_objects_1.png"
 }
 
 

--- a/conf.py
+++ b/conf.py
@@ -57,7 +57,6 @@ html_theme_options = {
     "use_edit_page_button": True,
     "launch_buttons": {
         "binderhub_url": "https://mybinder.org",
-        "colab_url": "https://colab.research.google.com"
 
     },
     "home_page_in_toc": True,


### PR DESCRIPTION
colab is not markdown notebook compatible, and anyway we never have had it configured up to install all the dependencies

Closes #67