### PR TITLE
CI: adding workarounds for ignoring broken notebook

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -70,3 +70,9 @@ html_static_path = ['_static']
 
 # myst configurations
 myst_heading_anchors = 4
+
+nb_execution_excludepatterns = []
+
+# Excluding knowingly broken notebook until
+# https://github.com/NASA-NAVO/navo-workshop/issues/197 is fixed
+nb_execution_excludepatterns += ['hr_diagram_solution.md',]

--- a/ignore_testing
+++ b/ignore_testing
@@ -1,0 +1,2 @@
+# The HR diagram notebook is broken: https://github.com/NASA-NAVO/navo-workshop/issues/197 
+content/use_case_notebooks/hr_diagram_solution

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ allowlist_externals = bash
 
 commands =
     pip freeze
-    !buildhtml: bash -c 'find content -name "*.md" | xargs jupytext --to notebook '
+    !buildhtml: bash -c 'find content -name "*.md" | grep -vf ignore_testing | xargs jupytext --to notebook '
 
     # We rerun the failed tests hoping that it filters out some flaky server behaviour
     !buildhtml: pytest --nbval --suppress-tests-failed-exit-code content/


### PR DESCRIPTION
This is a suboptimal workaround for #197, we exclude the notebook from testing and execution. IMO we should even remove it from the rendering in its current broken state, but that can be done in a follow-up.

So with this PR in, we are not masking other CI failures popping up with other notebooks. There are already a couple of them, but I plan to address those separately.