### PR TITLE
CI: using pytest-rerunfailures

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ deps =
     oldestdeps: scipy==1.6
     # Temporary fix for lexer errors
     ipython!=8.7.0
-    !buildhtml: pytest-custom_exit_code
+    !buildhtml: pytest-rerunfailures
 
 allowlist_externals = bash
 
@@ -37,8 +37,7 @@ commands =
     !buildhtml: bash -c 'find content -name "*.md" | grep -vf ignore_testing | xargs jupytext --to notebook '
 
     # We rerun the failed tests hoping that it filters out some flaky server behaviour
-    !buildhtml: pytest --nbval --suppress-tests-failed-exit-code content/
-    !buildhtml: pytest --nbval --last-failed --last-failed-no-failures none --suppress-no-test-exit-code content/
+    !buildhtml: pytest --nbval --reruns=1 --reruns-delay=30 content/
     buildhtml: sphinx-build -b html . _build/html -D nb_execution_mode=auto -nWT --keep-going
 
 pip_pre =


### PR DESCRIPTION
 instead of last-failed as cells are not standalone. Fixes https://github.com/NASA-NAVO/navo-workshop/issues/199