### PR TITLE
Updated notebook to use getdatalink method

### DIFF
--- a/content/reference_notebooks/spectral_access.md
+++ b/content/reference_notebooks/spectral_access.md
@@ -6,7 +6,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.4
+    jupytext_version: 1.16.6
 kernelspec:
   display_name: Python 3
   language: python
@@ -96,7 +96,8 @@ Accessing one of the spectra.
 # hdu_list = spec_tables[0].getdataobj()
 ## But if you might run this notebook repeatedly with limited bandwidth,
 ##  download it once and cache it.
-file_name = download_file(spec_tables[0].getdataurl(),cache=True)
+datalink = spec_tables[0].getdatalink()
+file_name = download_file(datalink.getvalue('access_url', 0),cache=True)
 hdu_list = fits.open(file_name)
 ```
 

--- a/content/use_case_notebooks/proposal_prep_solution.md
+++ b/content/use_case_notebooks/proposal_prep_solution.md
@@ -218,8 +218,9 @@ Hint 3: Download the data to make a spectrum. Note: you might end here and use X
 ```{code-cell} ipython3
 #  Get it and look at it:
 #hdu_list=spec_tables[0].getdataobj()
-file_name = download_file(spec_tables[0].getdataurl(), cache=True, timeout=600)
-hdu_list=fits.open(file_name)
+datalink = spec_tables[0].getdatalink()
+file_name = download_file(datalink.getvalue('access_url', 0),cache=True, timeout=600)
+hdu_list = fits.open(file_name)
 
 spectra=hdu_list[1].data
 print(spectra.columns)


### PR DESCRIPTION
Updated problematic cell with the following:
```python
## If you only run this once, you can do it in memory in one line:
##  This fetches the FITS as an astropy.io.fits object in memory
# hdu_list = spec_tables[0].getdataobj()
## But if you might run this notebook repeatedly with limited bandwidth,
##  download it once and cache it.
datalink = spec_tables[0].getdatalink()
file_name = download_file(datalink.getvalue('access_url', 0),cache=True)
hdu_list = fits.open(file_name)
```

Fixes #202 