### PR TITLE
Enable nb_scroll_outputs from latest myst-nb

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -38,6 +38,7 @@ exclude_patterns = ['_build', 'notes', '.tox', '.tmp', '.pytest_cache', 'README.
 
 # MyST-NB configuration
 nb_execution_timeout = 900
+nb_scroll_outputs = True
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/content/reference_notebooks/basic_reference.md
+++ b/content/reference_notebooks/basic_reference.md
@@ -206,8 +206,6 @@ file_name
 Example:  Find the HEASARC Table Access Protocol (TAP) service, get some information about the available tables.
 
 ```{code-cell} ipython3
-:tags: [output_scroll]
-
 services = vo.regsearch(servicetype='tap', keywords=['heasarc'])
 print(f'{len(services)} service(s) found.')
 # We found only one service.  Print some info about the service and its tables.

--- a/content/use_case_notebooks/candidate_list_exercise.md
+++ b/content/use_case_notebooks/candidate_list_exercise.md
@@ -163,8 +163,6 @@ Try a 60 arcsecond cutout.
 Repeat steps 5, 6, 8 through 12 for GALEX.
 
 ```{code-cell} ipython3
-:tags: [output_scroll]
-
 # Steps 5 & 6: Search the services found in step 4 for GALEX Sources
 # Hint: Choose the GALEX service on STSCI
 ```

--- a/content/use_case_notebooks/candidate_list_solution.md
+++ b/content/use_case_notebooks/candidate_list_solution.md
@@ -81,8 +81,6 @@ The next cell prepares the notebook to display our visualizations.
 Insert a Code Cell below by clicking on the "Insert" Menu and choosing "Insert Cell Below". Then consult QuickReference.md to figure out how to use astroquery to search NED for all objects in a paper, based on the refcode of the paper. Inspect the resulting astropy table.
 
 ```{code-cell} ipython3
-:tags: [output_scroll]
-
 objects_in_paper = Ned.query_refcode('2016ApJ...817..109O')
 objects_in_paper.show_in_notebook()
 ```
@@ -96,8 +94,6 @@ objects_in_paper['Type']
 ```
 
 ```{code-cell} ipython3
-:tags: [output_scroll]
-
 # Keep only the galaxies from the list
 galaxies = objects_in_paper[np.array(objects_in_paper['Type']) == 'G']
 

--- a/content/use_case_notebooks/hr_diagram_exercise.md
+++ b/content/use_case_notebooks/hr_diagram_exercise.md
@@ -72,8 +72,6 @@ To simplify this problem, we want to find a catalog of an open cluster of stars,
 Here is useful link for [how the pyvo registry search works](https://pyvo.readthedocs.io/en/latest/registry/index.html).
 
 ```{code-cell} ipython3
-:tags: [output_scroll]
-
 # Write some code to perform a registry search using
 # appropriate keywords and specify the service type.
 # Also apply the includeaux=True option to return
@@ -121,8 +119,6 @@ So using this we can reduce the matched tables to ones that are a bit more cater
 We can read more information about the results we found.  For each resource element (i.e. row in the table above), there are useful attributes, which are [described here]( https://pyvo.readthedocs.io/en/latest/api/pyvo.registry.regtap.RegistryResource.html#pyvo.registry.regtap.RegistryResource)
 
 ```{code-cell} ipython3
-:tags: [output_scroll]
-
 # Output the descriptions of the resulting matches:
 ```
 
@@ -134,7 +130,7 @@ We can read more information about the results we found.  For each resource elem
 
 ### Try a different data discovery method
 
-+++ {"tags": ["output_scroll"]}
++++
 
 ### Alternative Method: Use ADS to search for appropriate paper and access data via NED
 
@@ -197,8 +193,6 @@ Below are a few other ways to see what the tap_service table contains.
 2. tap_services[index].describe(): The table with the tap_services output has, in our case, 83 tables listed and each includes metadata containing some human readable description. You can get the description for one case or for all the records by iterating through the resource. In the former case, we show the description for the Eichhorn data. The latter case also follows.
 
 ```{code-cell} ipython3
-:tags: [output_scroll]
-
 # Print the full description for the Eichhorn+1970 example.
 ```
 

--- a/content/use_case_notebooks/hr_diagram_solution.md
+++ b/content/use_case_notebooks/hr_diagram_solution.md
@@ -72,8 +72,6 @@ To simplify this problem, we want to find a catalog of an open cluster of stars,
 Here is useful link for [how the pyvo registry search works](https://pyvo.readthedocs.io/en/latest/registry/index.html).
 
 ```{code-cell} ipython3
-:tags: [output_scroll]
-
 tap_services = registry.search(servicetype = 'tap', keywords=['star pleiades'], includeaux=True)
 print(len(tap_services))
 tap_services.get_summary()
@@ -90,8 +88,6 @@ Because we specified the service type, this returns only the TAP services for ea
 We can re-run the registry search, but further restrict the results by column UCD.  We want tables that have magnitude columns; the most basic UCD to describe a magnitude column is phot.mag
 
 ```{code-cell} ipython3
-:tags: [output_scroll]
-
 tap_services = registry.search(servicetype='tap', keywords=['star pleiades'],
                                ucd = ['phot.mag%'], includeaux=True)
 print(len(tap_services))
@@ -101,19 +97,15 @@ Note: the '%' serves as a wild card when searching by UCD
 
 The IOVA standard enables resources to be as sepecific as they would like when defining the UCD of columns.  For example, 'phot.mag' and 'phot.mag;em.opt.V' can both be used to describe a column containing the V magnitudes of objects.  If a resource uses the latter to describe a column, a search using 'phot.mag' will not return that resource.  A wild card would need to be used or the exact column UCD. The UCD search requires an exact match for a resource to be returned, so using the wild card will make it easier to discover a wider variety of resources.
 
-+++ {"tags": ["output_scroll"]}
++++
 
 So using this we can reduce the matched tables to ones that are a bit more catered to our experiment. Note, that there can be redundancy in some resources since these are available via multiple services and/or publishers. Therefore a bit more cleaning can be done to provide only the unique matches.
 
 ```{code-cell} ipython3
-:tags: [output_scroll]
-
 tap_services.to_table()['ivoid']
 ```
 
 ```{code-cell} ipython3
-:tags: [output_scroll]
-
 def getunique( result ):
     short_name = []
     unique_ind = []
@@ -129,19 +121,15 @@ def getunique( result ):
 ```
 
 ```{code-cell} ipython3
-:tags: [output_scroll]
-
 uniq_ind=getunique(tap_services)
 print(len(uniq_ind))
 ```
 
 ```{code-cell} ipython3
-:tags: [output_scroll]
-
 tap_services.to_table()[uniq_ind]['ivoid']
 ```
 
-+++ {"tags": ["output_scroll"]}
++++
 
 This shows that in this case, all of our TAP results are unique.
 
@@ -150,8 +138,6 @@ This shows that in this case, all of our TAP results are unique.
 We can read more information about the results we found.  For each resource element (i.e. row in the table above), there are useful attributes, which are [described here]( https://pyvo.readthedocs.io/en/latest/api/pyvo.registry.regtap.RegistryResource.html#pyvo.registry.regtap.RegistryResource)
 
 ```{code-cell} ipython3
-:tags: [output_scroll]
-
 # To read the descriptions of the resulting matches:
 
 for i in uniq_ind:
@@ -162,7 +148,7 @@ for i in uniq_ind:
 
 ```
 
-+++ {"tags": ["output_scroll"]}
++++
 
 <i> RESULT: Based on these, the second one (by Eichhorn et al) looks like a good start. </i>
 
@@ -172,7 +158,7 @@ for i in uniq_ind:
 
 ### Try a different data discovery method
 
-+++ {"tags": ["output_scroll"]}
++++
 
 ### Alternative Method: Use ADS to search for appropriate paper and access data via NED
 
@@ -222,8 +208,6 @@ Note that the URL is a generic TAP url for Vizier.  All of its tables can be acc
 Next, try using Author name:
 
 ```{code-cell} ipython3
-:tags: [output_scroll]
-
 author = 'Eichhorn'
 
 for record in tap_services:
@@ -255,35 +239,27 @@ Below are a few other ways to see what the tap_service table contains.
 2. tap_services[index].describe(): The table with the tap_services output has, in our case, 83 tables listed and each includes metadata containing some human readable description. You can get the description for one case or for all the records by iterating through the resource. In the former case, we show the description for the Eichhorn data, whose index is uniq_ind[1]. The latter case also follows.
 
 ```{code-cell} ipython3
-:tags: [output_scroll]
-
 print( tap_services.to_table().columns )
 ```
 
 ```{code-cell} ipython3
-:tags: [output_scroll]
-
 tap_services[uniq_ind[1]].describe()   # For Eichhorm+1970 example.
 ```
 
 ```{code-cell} ipython3
-:tags: [output_scroll]
-
 # To iterate over all the tables:
 for tapsvc in tap_services:
     print("---------------------------------------------  \n")
     tapsvc.describe()
 ```
 
-+++ {"tags": ["output_scroll"]}
++++
 
 ## Step 2: Acquire the relevant data and make a plot
 
 In order to query the table, we need the table name, note this is NOT the same as the short name we found above:
 
 ```{code-cell} ipython3
-:tags: [output_scroll]
-
 tables = tap_services[uniq_ind[1]].service.tables
 
 short_name = "I/90"
@@ -293,15 +269,13 @@ for name in tables.keys():
         print(name)
 ```
 
-+++ {"tags": ["output_scroll"]}
++++
 
 We can write code to eliminate the other cases (e.g., VI or VIII...) but we wanted to keep this cell to illustrate that the table name (which is required for the query) will likely include the short_name appended to "/catalog" (or "/table").
 
 But the other roman numeral catalogs are obviously different catalogs. Therefore try the below for a better match:
 
 ```{code-cell} ipython3
-:tags: [output_scroll]
-
 # find (more restricted) table name:
 for name in tables.keys():
     if name.startswith(short_name):
@@ -310,8 +284,6 @@ for name in tables.keys():
 ```
 
 ```{code-cell} ipython3
-:tags: [output_scroll]
-
 query = 'SELECT * FROM "%s"' %tablename
 print(query)
 results = tap_services[short_name].search(query)
@@ -362,8 +334,6 @@ tap_services[ind].describe()
 ```
 
 ```{code-cell} ipython3
-:tags: [output_scroll]
-
 # Doing steps above to view table from Raboud+1998
 
 # This 'tables' will return the same service tables as the 'tables' defined

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -1,6 +1,6 @@
 # Doc and testing requirements
 sphinx
-myst-nb>=0.14
+myst-nb>=1.3
 sphinx-book-theme
 sphinx-copybutton
 nbval

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -1,5 +1,6 @@
 # Doc and testing requirements
 sphinx
+# To pick up newest scroller and dark-mode features
 myst-nb>=1.3
 sphinx-book-theme
 sphinx-copybutton


### PR DESCRIPTION
~This PR is just a test for scroll_outputs functionality upcoming from upstream in https://github.com/executablebooks/MyST-NB/pull/683~

Fixes #102 
Undoes the #106 (since we have global config, we shouldn't hardcode scroller tag on cell level)

Test if the generated webpages have long outputs scrollable (bonus: also test dark mode style fixes that will come soon) - specifically the [Candidate List Solutions](https://output.circle-artifacts.com/output/job/a8645ce2-d3c0-46f0-8ede-c6e12e9ad527/artifacts/0/_build/html/content/use_case_notebooks/candidate_list_solution.html) (since others are ignored)