### PR TITLE
Fix catalog_queries notebook by making column names explicit

### DIFF
--- a/content/reference_notebooks/catalog_queries.md
+++ b/content/reference_notebooks/catalog_queries.md
@@ -313,7 +313,7 @@ The inline method is what PyVO will use.  These take a while, i.e. half a minute
 
 ```{code-cell} ipython3
 query="""
-    SELECT cat.ra, cat.dec, Radial_Velocity, bmag, morph_type
+    SELECT cat.ra as ra, cat.dec as dec, Radial_Velocity, bmag, morph_type
     FROM zcat cat, tap_upload.mysources mt
     WHERE
     contains(point('ICRS',cat.ra,cat.dec),circle('ICRS',mt.ra,mt.dec,0.01))=1

--- a/content/use_case_notebooks/hr_diagram_solution.md
+++ b/content/use_case_notebooks/hr_diagram_solution.md
@@ -268,6 +268,7 @@ But the other roman numeral catalogs are obviously different catalogs. Therefore
 ```{code-cell} ipython3
 # find (more restricted) table name:
 for name in tables.keys():
+    name = name.replace('"', '')
     if name.startswith(short_name):
         print(name)
         tablename=name

--- a/content/use_case_notebooks/hr_diagram_solution.md
+++ b/content/use_case_notebooks/hr_diagram_solution.md
@@ -335,6 +335,7 @@ tables = tap_services[ind].service.tables
 
 # find table name:
 for name in tables.keys():
+    name = name.replace('"', '')
     if short_name in name:
         tablename = name
 


### PR DESCRIPTION
The heasarc backend was recently updated so TAP queries return column names tablename_columnname instead of just columnname when join queries are made (e.g. uploads). This was needed to fixed other issues, but it has caused on query to fail in the catalog_queries notebook. The fix is to make the column names explicit by using `AS`.

CDS appears to be returned tables names with explicit double quote. This has caused some cells to fail. This PR add a line to remove them.